### PR TITLE
Fix segment ratio function

### DIFF
--- a/pygfunction/utilities.py
+++ b/pygfunction/utilities.py
@@ -39,6 +39,8 @@ def segment_ratios(nSegments, end_length_ratio=0.02):
         extraction boreholes. PhD Thesis. University of Lund, Department of
         Mathematical Physics. Lund, Sweden.
     """
+    # TODO: End length ratio of 0 < alpha < 0.5 should apply to all cases
+    # TODO: allow nSegments==2 and nSegments==1, but warn user for override about end_length_ratio
     def is_even(n):
         "Returns True if n is even."
         return not(n & 0x1)


### PR DESCRIPTION
The limit `0 < end_length_ratio < 0.5` should apply to all cases.

Also, in preparation for #153, we could consider here to allow `nSegments=2` and `nSegments=1` (which would simply return `segment_ratios=numpy.array([0.5, 0.5])` and `numpy.array([1.0])`). A warning will be required in these cases to warn the user that the `end_length_ratio` parameter is overwritten.

closes #159