### PR TITLE
Fix segment ratio function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [Issue 99](https://github.com/MassimoCimmino/pygfunction/issues/99) - Fixed an issue where `MultipleUTube._continuity_condition()` and `MultipleUTube._general_solution()` returned complex valued coefficient matrices.
 * [Issue 130](https://github.com/MassimoCimmino/pygfunction/issues/130) - Fix incorrect initialization of variables `_mix_out` and `_mixing_m_flow` in `Network`.
 * [Issue 155](https://github.com/MassimoCimmino/pygfunction/issues/155) - Fix incorrect initialization of variables in `Network` and `_BasePipe`. Stored variables are now initialized as `numpy.nan` instead of `numpy.empty`.
+* [Issue 159](https://github.com/MassimoCimmino/pygfunction/issues/159) - Fix `segment_ratios` function in the `utilities` module to always expect 0 < `end_length_ratio` < 0.5, and allows for `nSegments=1` or `nSegments=2`. If 1<=`nSegments`<3 then the user is warned that the `end_length_ratio` parameter is being over-ridden. 
 
 ## Version 2.0.0 (2021-05-22)
 

--- a/pygfunction/utilities.py
+++ b/pygfunction/utilities.py
@@ -44,19 +44,18 @@ def segment_ratios(nSegments, end_length_ratio=0.02):
         return not(n & 0x1)
     assert nSegments >= 1 and isinstance(nSegments, int), \
             "The number of segments `nSegments` should be greater or equal " \
-            "to 3 and of type int."
+            "to 1 and of type int."
     assert 0. < end_length_ratio < 0.5 and \
            isinstance(end_length_ratio, (float, np.floating)), \
             "The end-length-ratio `end_length_ratio` should be greater than " \
             "0, less than 0.5 (0 < end_length_ratio < 0.5) and of type float."
 
+    # If nSegments == 1, the only segment covers the entire length
     if nSegments == 1:
-        warnings.warn('nSegments = 1 has been provided. The '
-                      '`end_length_ratio` will be over-ridden. One segment '
-                      'ratio of [1.0] will be returned.')
         return np.array([1.0])
+    # If nSegments == 2, split the borehole in two even segments
     elif nSegments == 2:
-        warnings.warn('nSegments = 2 ahs been provided. The '
+        warnings.warn('nSegments = 2 has been provided. The '
                       '`end_length_ratio` will be over-ridden. Two segment '
                       'ratios of [0.5, 0.5] will be returned.')
         return np.array([0.5, 0.5])
@@ -144,7 +143,7 @@ def segment_ratios(nSegments, end_length_ratio=0.02):
             'A decreasing segment ratios discretization was found by '
             'utilities.segment_ratios(). Better accuracy is expected for '
             'increasing segment ratios. Consider decreasing the '
-            'end-length-ratio.')
+            'end-length-ratio such that end_length_ratio < 1 / nSegments.')
 
     return segment_ratios
 

--- a/pygfunction/utilities.py
+++ b/pygfunction/utilities.py
@@ -44,7 +44,7 @@ def segment_ratios(nSegments, end_length_ratio=0.02):
     def is_even(n):
         "Returns True if n is even."
         return not(n & 0x1)
-    assert nSegments >= 3 and isinstance(nSegments, int), \
+    assert nSegments >= 1 and isinstance(nSegments, int), \
             "The number of segments `nSegments` should be greater or equal " \
             "to 3 and of type int."
     assert end_length_ratio > 0. and isinstance(end_length_ratio, (float, np.floating)), \

--- a/pygfunction/utilities.py
+++ b/pygfunction/utilities.py
@@ -39,8 +39,6 @@ def segment_ratios(nSegments, end_length_ratio=0.02):
         extraction boreholes. PhD Thesis. University of Lund, Department of
         Mathematical Physics. Lund, Sweden.
     """
-    # TODO: End length ratio of 0 < alpha < 0.5 should apply to all cases
-    # TODO: allow nSegments==2 and nSegments==1, but warn user for override about end_length_ratio
     def is_even(n):
         "Returns True if n is even."
         return not(n & 0x1)
@@ -52,14 +50,26 @@ def segment_ratios(nSegments, end_length_ratio=0.02):
             "The end-length-ratio `end_length_ratio` should be greater than " \
             "0, less than 0.5 (0 < end_length_ratio < 0.5) and of type float."
 
+    if nSegments == 1:
+        warnings.warn('nSegments = 1 has been provided. The '
+                      '`end_length_ratio` will be over-ridden. One segment '
+                      'ratio of 1.0 will be returned.')
+        return np.array([1.0])
+    elif nSegments == 2:
+        warnings.warn('nSegments = 2 ahs been provided. The '
+                      '`end_length_ratio` will be over-ridden. Two segment '
+                      'ratios of [0.5, 0.5] will be returned.')
+        return np.array([0.5, 0.5])
     # If nSegments == 3, then the middle segment is simply the remainder of the
     # length
-    if nSegments == 3:
+    elif nSegments == 3:
         segment_ratios = np.array(
             [end_length_ratio,
              1 - 2 * end_length_ratio,
              end_length_ratio])
         return segment_ratios
+    else:
+        pass
 
     # If end_length_ratio == 1 / nSegments, then the discretization is
     # uniform

--- a/pygfunction/utilities.py
+++ b/pygfunction/utilities.py
@@ -53,7 +53,7 @@ def segment_ratios(nSegments, end_length_ratio=0.02):
     if nSegments == 1:
         warnings.warn('nSegments = 1 has been provided. The '
                       '`end_length_ratio` will be over-ridden. One segment '
-                      'ratio of 1.0 will be returned.')
+                      'ratio of [1.0] will be returned.')
         return np.array([1.0])
     elif nSegments == 2:
         warnings.warn('nSegments = 2 ahs been provided. The '

--- a/pygfunction/utilities.py
+++ b/pygfunction/utilities.py
@@ -45,7 +45,7 @@ def segment_ratios(nSegments, end_length_ratio=0.02):
     assert nSegments >= 1 and isinstance(nSegments, int), \
             "The number of segments `nSegments` should be greater or equal " \
             "to 1 and of type int."
-    assert 0. < end_length_ratio < 0.5 and \
+    assert nSegments <= 2 or 0. < end_length_ratio < 0.5 and \
            isinstance(end_length_ratio, (float, np.floating)), \
             "The end-length-ratio `end_length_ratio` should be greater than " \
             "0, less than 0.5 (0 < end_length_ratio < 0.5) and of type float."
@@ -55,9 +55,10 @@ def segment_ratios(nSegments, end_length_ratio=0.02):
         return np.array([1.0])
     # If nSegments == 2, split the borehole in two even segments
     elif nSegments == 2:
-        warnings.warn('nSegments = 2 has been provided. The '
-                      '`end_length_ratio` will be over-ridden. Two segment '
-                      'ratios of [0.5, 0.5] will be returned.')
+        if not np.abs(end_length_ratio - 0.5) < 1e-6:
+            warnings.warn('nSegments = 2 has been provided. The '
+                          '`end_length_ratio` will be over-ridden. Two '
+                          'segment ratios of [0.5, 0.5] will be returned.')
         return np.array([0.5, 0.5])
     # If nSegments == 3, then the middle segment is simply the remainder of the
     # length

--- a/pygfunction/utilities.py
+++ b/pygfunction/utilities.py
@@ -47,16 +47,14 @@ def segment_ratios(nSegments, end_length_ratio=0.02):
     assert nSegments >= 1 and isinstance(nSegments, int), \
             "The number of segments `nSegments` should be greater or equal " \
             "to 3 and of type int."
-    assert end_length_ratio > 0. and isinstance(end_length_ratio, (float, np.floating)), \
+    assert 0. < end_length_ratio < 0.5 and \
+           isinstance(end_length_ratio, (float, np.floating)), \
             "The end-length-ratio `end_length_ratio` should be greater than " \
-            "0. and of type float."
+            "0, less than 0.5 (0 < end_length_ratio < 0.5) and of type float."
 
     # If nSegments == 3, then the middle segment is simply the remainder of the
     # length
     if nSegments == 3:
-        assert end_length_ratio < 0.5, \
-            "For nSegments == 3, the end-length-ratio `end_length_ratio` " \
-            "should be less than 0.5."
         segment_ratios = np.array(
             [end_length_ratio,
              1 - 2 * end_length_ratio,

--- a/pygfunction/utilities.py
+++ b/pygfunction/utilities.py
@@ -39,6 +39,8 @@ def segment_ratios(nSegments, end_length_ratio=0.02):
         extraction boreholes. PhD Thesis. University of Lund, Department of
         Mathematical Physics. Lund, Sweden.
     """
+    # TODO: End length ratio of 0 < alpha < 0.5 should apply to all cases
+    # TODO: allow nSegments==2 and nSegments==1, but warn user for override about end_length_ratio
     def is_even(n):
         "Returns True if n is even."
         return not(n & 0x1)


### PR DESCRIPTION
The limit `0 < end_length_ratio < 0.5` should apply to all cases.

Also, in preparation for #153, we could consider here to allow `nSegments=2` and `nSegments=1` (which would simply return `segment_ratios=numpy.array([0.5, 0.5])` and `numpy.array([1.0])`). A warning will be required in these cases to warn the user that the `end_length_ratio` parameter is overwritten.

closes #159