### PR TITLE
Add fluid name attribute to Fluid, minor corrections to Grundmann reference

### DIFF
--- a/pygfunction/media.py
+++ b/pygfunction/media.py
@@ -78,6 +78,8 @@ class Fluid:
             raise ValueError(f'Unsupported fluid mixture: "{fluid_str}".')
 
         # Initialize all fluid properties
+        # Name
+        self.name = self.fluid.fluid_name
         # Temperature of the fluid (in Celsius)
         self.T_C = T
         # Density (in kg/m3)

--- a/pygfunction/pipes.py
+++ b/pygfunction/pipes.py
@@ -2876,7 +2876,7 @@ def convective_heat_transfer_coefficient_concentric_annulus(
 
     References
     ----------
-    .. [#Grundmann2007] Grundmann, R. (2016) Improved design methods for ground
+    .. [#Grundmann2016] Grundmann, R. (2016) Improved design methods for ground
         heat exchangers. Oklahoma State University, M.S. Thesis.
     .. [#ConvCoeff-CengelGhajar2015] Çengel, Y.A., & Ghajar, A.J. (2015). Heat
         and mass transfer: fundamentals & applications (Fifth edition.).


### PR DESCRIPTION
This PR:
- add a `name` attribute to the `Fluid` class for easier accessibility to the same scp attribute.
- Corrects the Grundmann reference.