### PR TITLE
Fix Numpy DeprecationWarning: Conversion of an array with ndim > 0 to a scalar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 2.3 (in development)
 
+### Bug fixes
+
+* [Issue 274](https://github.com/MassimoCimmino/pygfunction/issues/274) - Fixed scalar assignment from ndim-1 array. It is deprecated as of `numpy` version `1.25`. Only ndim-0 arrays can be treated as scalars.
+
 ## Version 2.2.2 (2023-01-09)
 
 ### Enhancements

--- a/pygfunction/pipes.py
+++ b/pygfunction/pipes.py
@@ -2259,7 +2259,7 @@ class Coaxial(SingleUTube):
         # Outer pipe to borehole wall thermal resistance
         R_fg = thermal_resistances(
             self.pos, self.r_out[self._iOuter], self.b.r_b, self.k_s, self.k_g,
-            R_fp, J=self.J)[1][0][0]
+            R_fp, J=self.J)[1][0,0]
         # Delta-circuit thermal resistances
         self._Rd = np.zeros((2*self.nPipes, 2*self.nPipes))
         self._Rd[self._iInner, self._iInner] = np.inf

--- a/pygfunction/pipes.py
+++ b/pygfunction/pipes.py
@@ -2259,7 +2259,7 @@ class Coaxial(SingleUTube):
         # Outer pipe to borehole wall thermal resistance
         R_fg = thermal_resistances(
             self.pos, self.r_out[self._iOuter], self.b.r_b, self.k_s, self.k_g,
-            R_fp, J=self.J)[1][0]
+            R_fp, J=self.J)[1][0][0]
         # Delta-circuit thermal resistances
         self._Rd = np.zeros((2*self.nPipes, 2*self.nPipes))
         self._Rd[self._iInner, self._iInner] = np.inf


### PR DESCRIPTION
Addresses the following Numpy warning.

```
tests/pipes_test.py: 42 warnings
  /Users/mattmitchell/Projects/pygfunction/pygfunction/pipes.py:2268: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    self._Rd[self._iOuter, self._iOuter] = R_fg
```