### PR TITLE
Optional matplotlib dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ target/
 
 # VirtualEnvironment
 venv/
+
+# Generated files
+*.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * [Issue 282](https://github.com/MassimoCimmino/pygfunction/issues/282) - Enabled the use of negative mass flow rates in `Pipe` and `Network` classes to model reversed flow direction.
 * [Pull Request 308](https://github.com/MassimoCimmino/pygfunction/pull/308) - Introduced a new `borefield` module. The new `Borefield` class replaces lists of `Borehole` objects as the preferred way to configure bore fields. The `Borefield.evaluate_g_function` method evaluates g-functions using the 'UHTR' and 'UBWT' boundary conditions. Deprecated bore field creation functions in the `boreholes` module (e.g. `boreholes.rectangle_field()`). These functions are replaced by methods of the new `Borefield` class. They will be removed in `v3.0.0`.
 
+### Other changes
+
+* [Issue 312](https://github.com/MassimoCimmino/pygfunction/issues/312) - The installation of `matplotlib` is now optional. Using `pip install pygfunction` will not install `matplotlib` and `pip install pygfunction[plot]` should be used instead.
+
 ## Version 2.2.3 (2024-07-01)
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ fluid temperatures in the boreholes for several U-tube pipe configurations.
 
 ## Requirements
 
-*pygfunction* was developed and tested using Python 3.7. In addition, the
+*pygfunction* was developed and tested using Python 3.8. In addition, the
 following packages are needed to run *pygfunction* and its examples:
-- matplotlib (>= 3.5.1),
+- matplotlib (>= 3.8.4),
 - numpy (>= 1.21.5)
 - scipy (>= 1.7.3)
 - SecondaryCoolantProps (>= 1.1)
+- typing_extensions >= 4.0.1
 
 The documentation is generated using [Sphinx](http://www.sphinx-doc.org). The
 following packages are needed to build the documentation:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This allows for the very fast calculation of *g*-functions, even for very large
 bore fields with hundreds of boreholes.
 
 Using *pygfunction*, *g*-functions can be calculated for any bore field
-configuration (i.e. arbitrarily positionned in space), including fields of
+configuration (i.e. arbitrarily positioned in space), including fields of
 boreholes with individually different lengths and radiuses. For regular fields
 of boreholes of equal size, setting-up the calculation of the *g*-function is
 as simple as a few lines of code. For example, the code for the calculation of

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ following packages are needed to build the documentation:
 **Users** - [Download pip](https://pip.pypa.io/en/latest/) and install the latest release:
 
 ```
-pip install pygfunction
+pip install pygfunction[plot]
 ```
 
 Alternatively, [download the latest release](https://github.com/MassimoCimmino/pygfunction/releases) and run the installation script:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,8 +1,8 @@
+matplotlib >= 3.8.4
 numpy >= 1.21.5
-scipy >= 1.7.3
-matplotlib >= 3.5.1
 numpydoc >= 1.2.0
 recommonmark >= 0.6.0
-sphinx >= 4.4.0
+scipy >= 1.7.3
 secondarycoolantprops >= 1.1.0
+sphinx >= 4.4.0
 typing_extensions >= 4.0.1

--- a/doc/source/examples/comparison_load_aggregation.rst
+++ b/doc/source/examples/comparison_load_aggregation.rst
@@ -6,7 +6,7 @@ Compare the accuracy and speed of different load aggregation algorithms
 
 This example compares the simulation times and the accuracy of borehole wall
 temperature predictions of different load aggregation algorithms implemented
-into the :doc:`load agggregation <load_aggregation>` module.
+into the :doc:`load aggregation <load_aggregation>` module.
 
 The g-function of a single borehole is first calculated. Then, the borehole wall
 temperature variations are calculated using the load aggregation schemes of

--- a/doc/source/examples/load_aggregation.rst
+++ b/doc/source/examples/load_aggregation.rst
@@ -5,7 +5,7 @@ Simulation of a borehole using load aggregation
 ***********************************************
 
 This example demonstrates the use of the
-:doc:`load agggregation <load_aggregation>` module to predict the borehole
+:doc:`load aggregation <load_aggregation>` module to predict the borehole
 wall temperature of a single temperature with known heat extraction rates.
 
 The g-function of a single borehole is first calculated. Then, the borehole wall

--- a/doc/source/examples/mixed_inlet_conditions.rst
+++ b/doc/source/examples/mixed_inlet_conditions.rst
@@ -15,7 +15,7 @@ constant.
 
 The following script generates the *g*-functions of a field of 5 equally spaced
 borehole on a straight line and connected in series. The boreholes have
-different lengths. The *g*-function considering piping conections is compared to
+different lengths. The *g*-function considering piping connections is compared to
 the *g*-function obtained using a boundary condition of uniform borehole wall
 temperature.
 

--- a/doc/source/examples/multiple_independent_Utubes.rst
+++ b/doc/source/examples/multiple_independent_Utubes.rst
@@ -12,7 +12,7 @@ in this example.
 The following script evaluates the fluid temperatures in a borehole with 4
 independent U-tubes with different inlet fluid temperatures and different inlet
 fluid mass flow rates. The resulting fluid temperature profiles are verified
-against the fluid temeprature profiles presented by Cimmino [1]_.
+against the fluid temperature profiles presented by Cimmino [1]_.
 
 The script is located in:
 `pygfunction/examples/multiple_independent_Utubes.py`

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -5,11 +5,11 @@ Setting up pygfunction
 **********************
 
 *pygfunction* uses Python 3.8, along with the following packages:
-	- matplotlib (>= 3.5.1),
 	- numpy (>= 1.21.5)
 	- scipy (>= 1.7.3)
 	- SecondaryCoolantProps (>= 1.1)
 	- typing_extensions (>= 4.0.1)
+	- (optionally) matplotlib (>= 3.8.4)
 
 *pygfunction*'s- documentation is built using:
 	- sphinx (>= 4.4.0)
@@ -18,30 +18,33 @@ Setting up pygfunction
 **Users** - `Download pip <https://pip.pypa.io/en/latest/>`_ and install the
 latest release:
 
-```
-pip install pygfunction
-```
+.. code:: shell
+
+	pip install pygfunction
+
+	pip install pygfunction[plot]
 
 Alternatively, `download the latest release
 <https://github.com/MassimoCimmino/pygfunction/releases>`_ and run the
 installation script:
 
-```
-pip install .
-```
+.. code:: shell
+
+	pip install .
 
 **Developers** - To get the latest version of the code, you can `download the
 repository from github <https://github.com/MassimoCimmino/pygfunction>`_ or
 clone the project in a local directory using git:
 
-```
-git clone https://github.com/MassimoCimmino/pygfunction.git
-```
+.. code:: shell
+
+	git clone https://github.com/MassimoCimmino/pygfunction.git
 
 Install *pygfunction* in development mode (this requires `pip >= 21.1`):
-```
-pip install --editable .
-```
+
+.. code:: shell
+
+	pip install --editable .
 
 Test that *pygfunction* is running correctly by running any of the
 provided examples in ``../pygfunction/examples/``

--- a/doc/source/nomenclature_tables/heat_transfer.csv
+++ b/doc/source/nomenclature_tables/heat_transfer.csv
@@ -14,5 +14,5 @@ Q_t,Watts,Total net heat extraction rate of a borehole or network
 R_b,m.K/W,Effective borehole thermal resistance
 R_fp,m.K/W,Fluid to outer pipe wall thermal resistance
 R_p,m.K/W,Conduction thermal resistance of a pipe wall
-T_b,degC,Effective borehole wall temprature
+T_b,degC,Effective borehole wall temperature
 T_f,degC,Fluid temperature

--- a/examples/bore_field_thermal_resistance.py
+++ b/examples/bore_field_thermal_resistance.py
@@ -8,7 +8,6 @@
 """
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.ticker import AutoMinorLocator
 
 import pygfunction as gt
 

--- a/examples/comparison_load_aggregation.py
+++ b/examples/comparison_load_aggregation.py
@@ -97,7 +97,7 @@ def main():
             # Apply current load
             LoadAgg.set_current_load(Q_b[i]/H)
 
-            # Evaluate borehole wall temeprature
+            # Evaluate borehole wall temperature
             deltaT_b = LoadAgg.temporal_superposition()
             T_b[n,i] = T_g - deltaT_b
         toc = perf_counter()

--- a/examples/custom_bore_field_from_file.py
+++ b/examples/custom_bore_field_from_file.py
@@ -2,6 +2,8 @@
 """ Example of definition of a bore field using custom borehole positions.
 
 """
+import os
+
 import pygfunction as gt
 
 
@@ -10,15 +12,16 @@ def main():
     # Parameters
     # -------------------------------------------------------------------------
 
-    # Filepath to bore field text file
-    filename = './data/custom_field_32_boreholes.txt'
+    # File path to bore field text file
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    file_path = os.path.join(base_dir, 'data', 'custom_field_32_boreholes.txt')
 
     # -------------------------------------------------------------------------
     # Borehole field
     # -------------------------------------------------------------------------
 
     # Build list of boreholes
-    borefield = gt.borefield.Borefield.from_file(filename)
+    borefield = gt.borefield.Borefield.from_file(file_path)
 
     # -------------------------------------------------------------------------
     # Draw bore field

--- a/examples/custom_borehole.py
+++ b/examples/custom_borehole.py
@@ -87,7 +87,7 @@ def main():
 
     # Check the geometry to make sure it is physically possible
 
-    # This class method is automatically called at the instanciation of the
+    # This class method is automatically called at the instantiation of the
     # pipe object and raises an error if the pipe geometry is invalid. It is
     # manually called here for demonstration.
     check_single = SingleUTube._check_geometry()

--- a/examples/discretize_boreholes.py
+++ b/examples/discretize_boreholes.py
@@ -11,10 +11,11 @@
     can be calculated accurately using a small number of segments.
 """
 
-import pygfunction as gt
-from numpy import pi
 import matplotlib.pyplot as plt
 import numpy as np
+from numpy import pi
+
+import pygfunction as gt
 
 
 def main():

--- a/examples/equal_inlet_temperature.py
+++ b/examples/equal_inlet_temperature.py
@@ -9,7 +9,6 @@
 """
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.ticker import AutoMinorLocator
 
 import pygfunction as gt
 

--- a/examples/fluid_temperature_reversible_flow_direction.py
+++ b/examples/fluid_temperature_reversible_flow_direction.py
@@ -45,7 +45,7 @@ def main():
     # Ground properties
     alpha = 2.5/2.2e6   # Ground thermal diffusivity (m2/s)
     k_s = 2.5           # Ground thermal conductivity (W/m.K)
-    T_g = 10.           # Undisturbed ground temperatue (degC)
+    T_g = 10.           # Undisturbed ground temperature (degC)
 
     # Grout properties
     k_g = 1.5           # Grout thermal conductivity (W/m.K)
@@ -91,7 +91,7 @@ def main():
     # Initialize bore field and pipe models
     # -------------------------------------------------------------------------
 
-    # The field is a retangular array
+    # The field is a rectangular array
     borefield = gt.borefield.Borefield.rectangle_field(
         N_1, N_2, B, B, H, D, r_b)
     nBoreholes = len(borefield)

--- a/examples/inclined_boreholes.py
+++ b/examples/inclined_boreholes.py
@@ -14,9 +14,9 @@
     extraction boreholes". Ph.D. Thesis, University of Lund, Lund, Sweden.
 """
 
-import pygfunction as gt
 import numpy as np
-import matplotlib.pyplot as plt
+
+import pygfunction as gt
 
 
 def main():

--- a/examples/load_aggregation.py
+++ b/examples/load_aggregation.py
@@ -72,7 +72,7 @@ def main():
         # Apply current load
         LoadAgg.set_current_load(Q_b_i/H)
 
-        # Evaluate borehole wall temeprature
+        # Evaluate borehole wall temperature
         deltaT_b = LoadAgg.temporal_superposition()
         T_b[i] = T_g - deltaT_b
 

--- a/examples/mixed_inlet_conditions.py
+++ b/examples/mixed_inlet_conditions.py
@@ -10,7 +10,6 @@
 """
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.ticker import AutoMinorLocator
 
 import pygfunction as gt
 

--- a/examples/multiple_independent_Utubes.py
+++ b/examples/multiple_independent_Utubes.py
@@ -9,10 +9,11 @@
     Cimmino (2016).
 
 """
+import os
+
 import matplotlib.lines as mlines
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.ticker import AutoMinorLocator
 
 import pygfunction as gt
 
@@ -55,7 +56,8 @@ def main():
     T_f_in = np.array([6.0, -6.0, 5.0, -5.0])
 
     # Path to validation data
-    filePath = './data/Cimmi16_multiple_independent_Utubes.txt'
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    file_path = os.path.join(base_dir, 'data', 'Cimmi16_multiple_independent_Utubes.txt')
 
     # -------------------------------------------------------------------------
     # Initialize pipe model
@@ -112,7 +114,7 @@ def main():
     # -------------------------------------------------------------------------
     # Load data from Cimmino (2016)
     # -------------------------------------------------------------------------
-    data = np.loadtxt(filePath, skiprows=1)
+    data = np.loadtxt(file_path, skiprows=1)
     ax1.plot(data[:,2:], data[:,0], 'b-',)
     reference = mlines.Line2D([], [],
                               color='blue',

--- a/examples/multipole_temperature.py
+++ b/examples/multipole_temperature.py
@@ -10,9 +10,10 @@
     against the results of Claesson and Hellstrom (2011).
 
 """
+import os
+
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.ticker import AutoMinorLocator
 
 import pygfunction as gt
 
@@ -51,7 +52,8 @@ def main():
     T_f = np.array([1., 1.])
 
     # Path to validation data
-    filePath = './data/ClaHel11_multipole_temperature.txt'
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    file_path = os.path.join(base_dir, 'data', 'ClaHel11_multipole_temperature.txt')
 
     # Thermal resistances for J=3
     R_Claesson = 0.01*np.array([25.592, 1.561, 25.311])
@@ -91,7 +93,7 @@ def main():
                                                x_T=x, y_T=y)
 
     # Load validation data
-    data = np.loadtxt(filePath, skiprows=1)
+    data = np.loadtxt(file_path, skiprows=1)
 
     # Configure figure and axes
     fig = gt.utilities._initialize_figure()

--- a/examples/unequal_segments.py
+++ b/examples/unequal_segments.py
@@ -6,7 +6,6 @@
     number of segments.
 """
 import matplotlib.pyplot as plt
-from matplotlib.ticker import AutoMinorLocator
 import numpy as np
 
 import pygfunction as gt

--- a/examples/uniform_heat_extraction_rate.py
+++ b/examples/uniform_heat_extraction_rate.py
@@ -6,10 +6,10 @@
     equal for all boreholes.
 
 """
-import matplotlib.lines as mlines
+import os
+
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.ticker import AutoMinorLocator
 
 import pygfunction as gt
 
@@ -29,7 +29,8 @@ def main():
     alpha = 1.0e-6      # Ground thermal diffusivity (m2/s)
 
     # Path to validation data
-    filePath = './data/CiBe14_uniform_heat_extraction_rate.txt'
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    file_path = os.path.join(base_dir, 'data', 'CiBe14_uniform_heat_extraction_rate.txt')
 
     # g-Function calculation options
     # The second field is evaluated with more segments to draw the
@@ -85,7 +86,7 @@ def main():
     # -------------------------------------------------------------------------
     # Load data from Cimmino and Bernier (2014)
     # -------------------------------------------------------------------------
-    data = np.loadtxt(filePath, skiprows=55)
+    data = np.loadtxt(file_path, skiprows=55)
 
     # -------------------------------------------------------------------------
     # Evaluate g-functions for all fields

--- a/examples/uniform_temperature.py
+++ b/examples/uniform_temperature.py
@@ -7,6 +7,8 @@
     boreholes, equal for all boreholes.
 
 """
+import os
+
 import matplotlib.pyplot as plt
 import numpy as np
 from time import perf_counter
@@ -29,7 +31,8 @@ def main():
     alpha = 1.0e-6      # Ground thermal diffusivity (m2/s)
 
     # Path to validation data
-    filePath = './data/CiBe14_uniform_temperature.txt'
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    file_path = os.path.join(base_dir, 'data', 'CiBe14_uniform_temperature.txt')
 
     # g-Function calculation options
     # A uniform discretization is used to compare results with Cimmino and
@@ -72,7 +75,7 @@ def main():
     # -------------------------------------------------------------------------
     # Load data from Cimmino and Bernier (2014)
     # -------------------------------------------------------------------------
-    data = np.loadtxt(filePath, skiprows=55)
+    data = np.loadtxt(file_path, skiprows=55)
 
     # -------------------------------------------------------------------------
     # Evaluate g-functions for all fields

--- a/pygfunction/__init__.py
+++ b/pygfunction/__init__.py
@@ -1,9 +1,11 @@
-from . import boreholes
-from . import borefield
-from . import gfunction
-from . import heat_transfer
-from . import load_aggregation
-from . import media
-from . import networks
-from . import pipes
-from . import utilities
+from . import (
+    borefield,
+    boreholes,
+    gfunction,
+    heat_transfer,
+    load_aggregation,
+    media,
+    networks,
+    pipes,
+    utilities,
+)

--- a/pygfunction/_mpl.py
+++ b/pygfunction/_mpl.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+try:
+    import matplotlib.pyplot as plt
+    from matplotlib.ticker import AutoMinorLocator
+except ImportError as err:
+    raise ImportError(
+        "Matplotlib is required for plotting. Install it with "
+        "`pip install pygfunction[plot]`"
+    ) from err
+
+__all__ = ["plt", "AutoMinorLocator"]

--- a/pygfunction/borefield.py
+++ b/pygfunction/borefield.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 from typing import Union, List, Dict, Tuple
-from typing_extensions import Self     # for compatibility with Python <= 3.10
 
-import matplotlib.pyplot as plt
-from matplotlib.figure import Figure
 import numpy as np
 import numpy.typing as npt
+from typing_extensions import Self  # for compatibility with Python <= 3.10
 
 from .boreholes import Borehole
 from .utilities import _initialize_figure, _format_axes, _format_axes_3d
@@ -308,7 +306,7 @@ class Borefield:
 
     def visualize_field(
             self, viewTop: bool = True, view3D: bool = True,
-            labels: bool = True, showTilt: bool = True) -> Figure:
+            labels: bool = True, showTilt: bool = True):
         """
         Plot the top view and 3D view of borehole positions.
 
@@ -333,6 +331,8 @@ class Borefield:
             Figure object (matplotlib).
 
         """
+        from ._mpl import plt
+
         # Configure figure and axes
         fig = _initialize_figure()
         if viewTop and view3D:

--- a/pygfunction/boreholes.py
+++ b/pygfunction/boreholes.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import warnings
 
-import matplotlib.pyplot as plt
 import numpy as np
 from scipy.spatial.distance import pdist
 
@@ -1386,6 +1385,8 @@ def visualize_field(
                   "deprecated as of v2.3. It will be removed in v3.0. "
                   "Use the `pygfunction.borefield.Borefield` class instead.",
                   DeprecationWarning)
+
+    from ._mpl import plt
 
     # Configure figure and axes
     fig = _initialize_figure()

--- a/pygfunction/gfunction.py
+++ b/pygfunction/gfunction.py
@@ -1,21 +1,19 @@
 # -*- coding: utf-8 -*-
-from time import perf_counter
 import warnings
+from time import perf_counter
 
-import matplotlib.pyplot as plt
 import numpy as np
 from scipy.cluster.hierarchy import cut_tree, dendrogram, linkage
 from scipy.constants import pi
 from scipy.interpolate import interp1d as interp1d
 
-from .boreholes import Borehole, _EquivalentBorehole, find_duplicates
 from .borefield import Borefield
+from .boreholes import Borehole, _EquivalentBorehole, find_duplicates
 from .heat_transfer import finite_line_source, finite_line_source_vectorized, \
     finite_line_source_equivalent_boreholes_vectorized, \
     finite_line_source_inclined_vectorized
 from .networks import Network, _EquivalentNetwork, network_thermal_resistance
-from .utilities import _initialize_figure, _format_axes
-from . import utilities
+from .utilities import _initialize_figure, _format_axes, segment_ratios
 
 
 class gFunction(object):
@@ -335,6 +333,8 @@ class gFunction(object):
             Figure object (matplotlib).
 
         """
+        from ._mpl import plt
+
         # Configure figure and axes
         fig = _initialize_figure()
         ax = fig.add_subplot(111)
@@ -400,6 +400,8 @@ class gFunction(object):
             Figure object (matplotlib).
 
         """
+        from ._mpl import plt
+
         # If iBoreholes is None, then plot all boreholes
         if iBoreholes is None:
             iBoreholes = range(len(self.solver.boreholes))
@@ -549,6 +551,8 @@ class gFunction(object):
             Figure object (matplotlib).
 
         """
+        from ._mpl import plt
+
         # If iBoreholes is None, then plot all boreholes
         if iBoreholes is None:
             iBoreholes = range(len(self.solver.boreholes))
@@ -693,6 +697,8 @@ class gFunction(object):
             Figure object (matplotlib).
 
         """
+        from ._mpl import plt
+
         # If iBoreholes is None, then plot all boreholes
         if iBoreholes is None:
             iBoreholes = range(len(self.solver.boreholes))
@@ -838,6 +844,8 @@ class gFunction(object):
             Figure object (matplotlib).
 
         """
+        from ._mpl import plt
+
         # If iBoreholes is None, then plot all boreholes
         if iBoreholes is None:
             iBoreholes = range(len(self.boreholes))
@@ -961,7 +969,7 @@ class gFunction(object):
         Parameters
         ----------
         iBoreholes : list of int
-            Borehole indices to extract heat extration rates.
+            Borehole indices to extract heat extraction rates.
 
         Returns
         -------
@@ -1413,7 +1421,7 @@ def uniform_heat_extraction(boreholes, time, alpha, use_similarities=True,
 
 
 def uniform_temperature(boreholes, time, alpha, nSegments=8,
-                        segment_ratios=utilities.segment_ratios, kind='linear',
+                        segment_ratios=segment_ratios, kind='linear',
                         use_similarities=True, disTol=0.01, tol=1.0e-6,
                         dtype=np.double, disp=False, **kwargs):
     """
@@ -1523,7 +1531,7 @@ def uniform_temperature(boreholes, time, alpha, nSegments=8,
 
 def equal_inlet_temperature(
         boreholes, UTubes, m_flow_borehole, cp_f, time, alpha,
-        kind='linear', nSegments=8, segment_ratios=utilities.segment_ratios,
+        kind='linear', nSegments=8, segment_ratios=segment_ratios,
         use_similarities=True, disTol=0.01, tol=1.0e-6, dtype=np.double,
         disp=False, **kwargs):
     """
@@ -1632,7 +1640,7 @@ def equal_inlet_temperature(
 
 def mixed_inlet_temperature(
         network, m_flow_network, cp_f, time, alpha, kind='linear',
-        nSegments=8, segment_ratios=utilities.segment_ratios,
+        nSegments=8, segment_ratios=segment_ratios,
         use_similarities=True, disTol=0.01, tol=1.0e-6, dtype=np.double,
         disp=False, **kwargs):
     """
@@ -1856,7 +1864,7 @@ class _BaseSolver(object):
     """
     def __init__(self, boreholes, network, time, boundary_condition,
                  m_flow_borehole=None, m_flow_network=None, cp_f=None,
-                 nSegments=8, segment_ratios=utilities.segment_ratios,
+                 nSegments=8, segment_ratios=segment_ratios,
                  approximate_FLS=False, mQuad=11, nFLS=10,
                  linear_threshold=None, disp=False, profiles=False,
                  kind='linear', dtype=np.double, **other_options):

--- a/pygfunction/gfunction.py
+++ b/pygfunction/gfunction.py
@@ -4634,7 +4634,7 @@ class _Equivalent(_BaseSolver):
 
     def _find_unique_distances(self, dis, indices):
         """
-        Find the number of occurences of each unique distances between pairs
+        Find the number of occurrences of each unique distances between pairs
         of boreholes.
 
         Parameters

--- a/pygfunction/heat_transfer.py
+++ b/pygfunction/heat_transfer.py
@@ -532,18 +532,18 @@ def finite_line_source_inclined_approximation(
                 rb1, x1, y1, H1, D1, tilt1, orientation1,
                 x2, y2, H2, D2, tilt2, orientation2)])
     # Number of dimensions of the output, excluding time
-    ouput_ndim = len(output_shape)
+    output_ndim = len(output_shape)
     # Shape of the time variable
     time_shape = np.shape(time)
     # Number of dimensions of the time variable
     time_ndim = len(time_shape)
     # Roots for Gauss-Legendre quadrature
     x, w = roots_legendre(M)
-    u = (0.5 * x + 0.5).reshape((-1, 1) + (1,) * ouput_ndim)
+    u = (0.5 * x + 0.5).reshape((-1, 1) + (1,) * output_ndim)
     w = w / 2
     # Coefficients of the approximation of the error function
     a, b = _erf_coeffs(N)
-    b = b.reshape((1, -1) + (1,) * ouput_ndim)
+    b = b.reshape((1, -1) + (1,) * output_ndim)
     # Sines and cosines of tilt (b: beta) and orientation (t: theta)
     sb1 = np.sin(tilt1)
     sb2 = np.sin(tilt2)

--- a/pygfunction/load_aggregation.py
+++ b/pygfunction/load_aggregation.py
@@ -39,7 +39,7 @@ class _LoadAggregation(object):
     def temporal_superposition(self):
         raise NotImplementedError(
             'temporal_superposition class method not implemented, this '
-            'method should return the borehole wall tempreatures at the '
+            'method should return the borehole wall temperatures at the '
             'current time step.')
 
 
@@ -122,7 +122,7 @@ class ClaessonJaved(_LoadAggregation):
             Array of **dimensional** thermal response factor increments used
             for temporal superposition
             (:math:`g(t_{i+1})/(2 \\pi k_s) - g(t_{i})/(2 \\pi k_s)`),
-            in correspondance with the intialized values of the thermal
+            in correspondence with the initialized values of the thermal
             response factors in
             :func:`~load_aggregation.ClaessonJaved.initialize`.
             The output size of the array is (nSources, nSources, Nt) if

--- a/pygfunction/pipes.py
+++ b/pygfunction/pipes.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-import matplotlib.pyplot as plt
+import warnings
+
 import numpy as np
 from scipy.constants import pi
 from scipy.special import binom
-import warnings
 
 from .utilities import _initialize_figure, _format_axes
 
@@ -735,7 +735,6 @@ class _BasePipe(object):
             'update_thermal_resistances class method not implemented, '
             'this method should update the array of delta-circuit thermal '
             'resistances.')
-        return
 
     def visualize_pipes(self):
         """
@@ -747,6 +746,8 @@ class _BasePipe(object):
             Figure object (matplotlib).
 
         """
+        from ._mpl import plt
+
         # Configure figure and axes
         fig = _initialize_figure()
         ax = fig.add_subplot(111)
@@ -2645,6 +2646,8 @@ class Coaxial(SingleUTube):
             Figure object (matplotlib).
 
         """
+        from ._mpl import plt
+
         # Configure figure and axes
         fig = _initialize_figure()
         ax = fig.add_subplot(111)

--- a/pygfunction/pipes.py
+++ b/pygfunction/pipes.py
@@ -2413,7 +2413,7 @@ class IndependentMultipleUTube(MultipleUTube):
         self._check_model_variables(
             m_flow_borehole, cp_f, nSegments, segment_ratios)
 
-        # All upward flowing pipes are connceted to their respective outlet
+        # All upward flowing pipes are connected to their respective outlet
         c_fu = np.eye(self.nPipes)
 
         return c_fu
@@ -2770,9 +2770,9 @@ class Coaxial(SingleUTube):
         return True
 
 
-# Dictionnary of inputs and outputs for thermal_resistance function
+# Dictionary of inputs and outputs for thermal_resistance function
 # The inputs and outputs of the last call to the function are saved into this
-# dictionnary to save calculation time on repeated calls.
+# dictionary to save calculation time on repeated calls.
 _thermal_resistances_dict = {
     'pos': None, 'r_out': None, 'r_b': None, 'k_s': None, 'k_g': None,
     'R_fp': None, 'J': None, 'R': None, 'Rd': None}
@@ -2781,7 +2781,7 @@ _thermal_resistances_dict = {
 def _compare_thermal_resistances_inputs(
         pos, r_out, r_b, k_s, k_g, R_fp, J, tol=1e-6):
     """
-    Compare inputs to the content of the _thermal_resistances_dict dictionnary.
+    Compare inputs to the content of the _thermal_resistances_dict dictionary.
 
     Parameters
     ----------
@@ -2807,10 +2807,10 @@ def _compare_thermal_resistances_inputs(
     Returns
     -------
     bool
-        True if the inputs are the same as the content of the dictionnary.
+        True if the inputs are the same as the content of the dictionary.
 
     """
-    # Return False if dictionnary is empty
+    # Return False if dictionary is empty
     for arg in ('pos', 'r_out', 'r_b', 'k_s', 'k_g', 'R_fp', 'J'):
         if _thermal_resistances_dict[arg] is None:
             return False
@@ -2954,7 +2954,7 @@ def thermal_resistances(pos, r_out, r_b, k_s, k_g, R_fp, J=2):
                     sum([K[i, j] for j in range(n_p) if not i == j]))
     Rd = 1.0/K
 
-    # Save outputs into dictionnary
+    # Save outputs into dictionary
     _thermal_resistances_dict['pos'] = pos
     _thermal_resistances_dict['r_out'] = r_out
     _thermal_resistances_dict['r_b'] = r_b
@@ -3099,7 +3099,7 @@ def convective_heat_transfer_coefficient_circular_pipe(
     for constant pipe wall surface temperature is used for laminar flow.
 
     Since :func:`_Nusselt_number_turbulent_flow` is only valid for Re > 3000.
-    and to avoid dicontinuities in the values of the convective heat transfer
+    and to avoid discontinuities in the values of the convective heat transfer
     coefficient near the onset of the turbulence region (approximately
     Re = 2300.), linear interpolation is used over the range 2300 < Re < 4000
     for the evaluation of the Nusselt number.

--- a/pygfunction/utilities.py
+++ b/pygfunction/utilities.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-import matplotlib.pyplot as plt
+import warnings
+
 import numpy as np
 import numpy.polynomial.polynomial as poly
 from scipy.special import erf
-import warnings
 
 
 def cardinal_point(direction):
@@ -366,6 +366,8 @@ def _initialize_figure():
         Figure object (matplotlib).
 
     """
+    from ._mpl import plt
+
     plt.rc('font', size=9)
     plt.rc('xtick', labelsize=9)
     plt.rc('ytick', labelsize=9)
@@ -385,7 +387,8 @@ def _format_axes(ax):
         Axis object (matplotlib).
 
     """
-    from matplotlib.ticker import AutoMinorLocator
+    from ._mpl import AutoMinorLocator
+
     # Draw major and minor tick marks inwards
     ax.tick_params(
         axis='both', which='both', direction='in',
@@ -406,7 +409,6 @@ def _format_axes_3d(ax):
         Axis object (matplotlib).
 
     """
-    from matplotlib.ticker import AutoMinorLocator
     # Draw major and minor tick marks inwards
     ax.tick_params(
         axis='both', which='major', direction='in',

--- a/pygfunction/utilities.py
+++ b/pygfunction/utilities.py
@@ -480,7 +480,7 @@ def _erf_coeffs(N):
     """
     Return the coefficients of the approximation of the error function.
 
-    This returns the coefficents (a_n, b_n) of the approximation of the error
+    This returns the coefficients (a_n, b_n) of the approximation of the error
     function adapted from the work of Tanash and Riihonen (2020)
     [#erf-TanRii2020]_. The approximation of the error function is given by:
 
@@ -497,9 +497,9 @@ def _erf_coeffs(N):
     Returns
     -------
     a : array
-        Array of oefficients a_n.
+        Array of coefficients a_n.
     b : array
-        Array of oefficients b_n.
+        Array of coefficients b_n.
 
     References
     ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,6 @@ addopts = "--cov=pygfunction"
 testpaths = [
     "tests",
 ]
+
+[tool.coverage.run]
+omit = ["pygfunction/_mpl.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+matplotlib
 numpy
 scipy
-matplotlib
 SecondaryCoolantProps
 typing_extensions

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 numpydoc == 1.2.0
-recommonmark == 0.6.0
-sphinx == 4.4.0
 pytest == 7.1.1
 pytest-cov == 3.0.0
+recommonmark == 0.6.0
+sphinx == 4.4.0
 tox == 3.24.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,11 +24,11 @@ classifiers =
 [options]
 packages = pygfunction
 install_requires =
-    matplotlib >= 3.5.1
     numpy >= 1.21.5
     scipy >= 1.7.3
     secondarycoolantprops >= 1.1
     typing_extensions >= 4.0.1
+
 python_requires = >=3.8
 
 [options.extras_require]
@@ -36,7 +36,10 @@ doc =
     numpydoc >= 1.2.0
     recommonmark >= 0.6.0
     sphinx >= 4.4.0
+plot =
+    matplotlib >= 3.8.4
 testing =
+    matplotlib >= 3.8.4
     pytest >= 7.1.1
     pytest-cov >= 3.0.0
     tox >= 3.24.5


### PR DESCRIPTION
This PR refactors all `matplotlib` imports to be lazily imported with graceful error-handling to separate core functionality from visualization.

Pygfunction can now be installed with optional matplotlib support:
- `pip install pygfunction`
- `pip install pygfunction[plot]`

Attempting to call a function like `borefield.visualize_field()` without the `plot` extra will result in the error:
> ImportError: Matplotlib is required for plotting. Install it with `pip install pygfunction[plot]`

It also fixes a small handful of typos, and updates the minimum matplotlib version for compatibility with NumPy 2.0.